### PR TITLE
refactor: move hero and form inline styles to CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,31 +52,31 @@
   </header>
 
 <!-- ░░ HERO + QUOTE FORM ░░ -->
-<section class="hero" style="background:#ECF1EF;padding:3rem 0 1rem;">
-  <div class="hero-container" style="max-width:580px;margin:0 auto;">
-    <div class="review-badge" style="text-align:center;margin-bottom:1.2rem;">
-      <span style="color:#FFB300;font-size:1.5rem;">★★★★★</span>
-      <span style="margin-left:.5rem;color:#233038;">Rated 5 on Google & Direct Reviews</span>
+<section class="hero hero-quote">
+  <div class="hero-container">
+    <div class="review-badge">
+      <span class="stars">★★★★★</span>
+      <span class="rating-text">Rated 5 on Google & Direct Reviews</span>
     </div>
-    <h1 style="text-align:center;margin-bottom:.5rem;">Book Your RICS Home Survey — Fast, Clear &amp; Local</h1>
-    <p style="text-align:center;margin-bottom:1.5rem;">Make confident property decisions with a qualified surveyor’s report — turnaround in as little as 5–7&nbsp;days. Get your tailored quote now and secure your survey date.</p>
+    <h1>Book Your RICS Home Survey — Fast, Clear &amp; Local</h1>
+    <p>Make confident property decisions with a qualified surveyor’s report — turnaround in as little as 5–7&nbsp;days. Get your tailored quote now and secure your survey date.</p>
 
-    <form class="quote-form" action="https://formspree.io/f/xzzdqqqz" method="POST" style="background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.08);padding:2rem 1.5rem;margin-bottom:2rem;">
+    <form class="quote-form" action="https://formspree.io/f/xzzdqqqz" method="POST">
       <input type="hidden" name="_next" value="/thank-you.html"/>
-      <div style="display:grid;gap:1rem;">
-        <label style="display:flex;flex-direction:column;gap:.25rem;">Your Name
+      <div class="form-grid">
+        <label>Your Name
           <input type="text" name="name" placeholder="e.g. Jane Smith" required/>
         </label>
-        <label style="display:flex;flex-direction:column;gap:.25rem;">Email
+        <label>Email
           <input type="email" name="email" placeholder="e.g. jane@example.com" required/>
         </label>
-        <label style="display:flex;flex-direction:column;gap:.25rem;">Contact Number
+        <label>Contact Number
           <input type="text" name="contact" placeholder="e.g. 01234 567890" required/>
         </label>
-        <label style="display:flex;flex-direction:column;gap:.25rem;">Postcode
+        <label>Postcode
           <input type="text" name="postcode" placeholder="e.g. CH1 2AB" required/>
         </label>
-        <label style="display:flex;flex-direction:column;gap:.25rem;">Survey Type
+        <label>Survey Type
           <select name="survey-type" required>
             <option value="">Select a survey type</option>
             <option value="level-1">Level 1 — Condition Report</option>
@@ -85,12 +85,12 @@
             <option value="unsure">Unsure</option>
           </select>
         </label>
-        <label style="display:flex;flex-direction:column;gap:.25rem;">No. of Bedrooms
+        <label>No. of Bedrooms
           <input type="text" name="bedrooms" placeholder="e.g. 3" required/>
         </label>
-        <button type="submit" class="cta-button hero-contrast" style="margin-top:1rem;width:100%;">Get My Survey Quote in 60 Minutes</button>
+        <button type="submit" class="cta-button hero-contrast">Get My Survey Quote in 60 Minutes</button>
       </div>
-      <ul style="list-style:disc inside;margin-top:1.5rem;color:#233038;font-size:1rem;text-align:left;">
+      <ul>
         <li><strong>Fast, no-obligation quote</strong> direct from a surveyor</li>
         <li><strong>Out-of-hours responses</strong> whenever possible</li>
         <li>100% privacy — your details are <strong>never shared</strong></li>

--- a/styles.css
+++ b/styles.css
@@ -308,6 +308,76 @@ form button:hover, .quote-form button:hover {
 }
 
 /*──────────────────────────────────────────────
+  HOME HERO QUOTE FORM
+──────────────────────────────────────────────*/
+.hero-quote {
+  background: #ECF1EF;
+  padding: 3rem 0 1rem;
+}
+
+.hero-quote .hero-container {
+  max-width: 580px;
+  margin: 0 auto;
+}
+
+.review-badge {
+  text-align: center;
+  margin-bottom: 1.2rem;
+}
+
+.review-badge .stars {
+  color: #FFB300;
+  font-size: 1.5rem;
+}
+
+.review-badge .rating-text {
+  margin-left: .5rem;
+  color: #233038;
+}
+
+.hero-quote h1 {
+  text-align: center;
+  margin-bottom: .5rem;
+}
+
+.hero-quote > p {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.quote-form {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.08);
+  padding: 2rem 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.quote-form .form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.quote-form label {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+
+.quote-form button {
+  margin-top: 1rem;
+  width: 100%;
+}
+
+.quote-form ul {
+  list-style: disc inside;
+  margin-top: 1.5rem;
+  color: #233038;
+  font-size: 1rem;
+  text-align: left;
+}
+
+/*──────────────────────────────────────────────
   13. STICKY CTA
 ──────────────────────────────────────────────*/
 .sticky-cta {


### PR DESCRIPTION
## Summary
- move homepage hero and quote form inline styles into dedicated CSS classes
- clean up index markup by replacing `style` attributes with semantic class names

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `npx --yes prettier@2.8.8 -c index.html styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689c40e808e883239cb6eee784d3d93d