### PR TITLE
Clean up services.html head and remove duplicate markup

### DIFF
--- a/services.html
+++ b/services.html
@@ -9,47 +9,6 @@
   <meta name="keywords" content="RICS Home Survey, Building Survey, Damp Report, Measured Survey, Floorplans, EPC with Floorplan, Ventilation Assessment, Property Surveyor Deeside Chester Flintshire" />
   <link rel="stylesheet" href="/styles.css" />
   <link rel="icon" href="/favicon.ico" />
-  
-  <!-- Cookie Consent Mode with Usercentrics -->
-<script src="https://web.cmp.usercentrics.eu/modules/autoblocker.js"></script>
-<script id="usercentrics-cmp" src="https://web.cmp.usercentrics.eu/ui/loader.js" data-settings-id="53YNyaAqMpXqyj" async></script>
-
-<!-- Google tag (gtag.js) for GA4 -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-GXH0EY936M');
-</script>
-  
-</head>
-<body>
-  <!-- HEADER INCLUDE -->
-  <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  
-</script>
-  <meta name="description"
-        content="LEM Building Surveying Ltd. – Professional property surveys across North Wales, Chester, and the North West." />
-<head>
-	
-  <!-- Main CSS -->
-  <link rel="stylesheet" href="styles.css" />
-
-  <!-- CTA colour override for header only -->
-  <style>
-    /* Use your “sage” for buttons on charcoal (header) */
-    .main-nav a.cta {
-      background-color: var(--sage-grey) !important;
-      color:       var(--text-dark) !important;
-    }
-    .main-nav a.cta:hover {
-      background-color: var(--light-grey) !important;
-    }
-  </style>
-</head>
   <!-- Font Awesome -->
   <link
     rel="stylesheet"
@@ -58,32 +17,32 @@
     crossorigin="anonymous"
     referrerpolicy="no-referrer"
   />
-
-  <!-- Main CSS -->
-  <link rel="stylesheet" href="/styles.css" />
-
-  <title>LEM Building Surveying Ltd.</title>
+  <!-- Cookie Consent Mode with Usercentrics -->
+  <script src="https://web.cmp.usercentrics.eu/modules/autoblocker.js"></script>
+  <script id="usercentrics-cmp" src="https://web.cmp.usercentrics.eu/ui/loader.js" data-settings-id="53YNyaAqMpXqyj" async></script>
+  <!-- Google tag (gtag.js) for GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-GXH0EY936M');
+  </script>
+  <!-- CTA colour override for header only -->
+  <style>
+    /* Use your “sage” for buttons on charcoal (header) */
+    .main-nav a.cta {
+      background-color: var(--sage-grey) !important;
+      color: var(--text-dark) !important;
+    }
+    .main-nav a.cta:hover {
+      background-color: var(--light-grey) !important;
+    }
+  </style>
 </head>
 <body>
-
-  <header>
-    <div class="header-inner">
-      <div class="branding">
-        <a href="/index.html" class="logo-link" aria-label="LEM Building Surveying Ltd home">
-          <img src="/logo-sticker.png" alt="LEM Building Surveying Ltd Logo" class="logo" />
-          <span class="site-name">LEM Building Surveying Ltd.</span>
-        </a>
-      </div>
-      <nav class="main-nav" aria-label="Main Navigation">
-        <ul>
-          <li><a href="/index.html">Home</a></li>
-          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
-          
-          <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <!-- HEADER INCLUDE -->
+  <div id="header-include"></div>
 
   <!-- HERO -->
   <section class="hero">
@@ -201,4 +160,4 @@
   </script>
 </body>
 </html>
-<!DOCTYPE html><html lang="en"><head>  <meta charset="UTF-8" />  <meta name="viewport" content="width=device-width, initial-scale=1.0" />  <title>Property Surveying Services | RICS Surveys, Damp Reports & EPCs | LEM Building Surveying Ltd</title>  <meta name="description" content="Explore the full range of property surveying services from LEM Building Surveying Ltd: RICS Home Surveys, Damp & Timber Reports, Measured Surveys, EPCs, Ventilation Assessments and more across Deeside, Chester & the North West." />  <meta name="keywords" content="RICS Home Survey, Building Survey, Damp Report, Measured Survey, Floorplans, EPC with Floorplan, Ventilation Assessment, Property Surveyor Deeside Chester Flintshire" />  <link rel="stylesheet" href="/styles.css" />  <link rel="icon" href="/favicon.ico" />    <!-- Cookie Consent Mode with Usercentrics --><script src="https://web.cmp.usercentrics.eu/modules/autoblocker.js"></script><script id="usercentrics-cmp" src="https://web.cmp.usercentrics.eu/ui/loader.js" data-settings-id="53YNyaAqMpXqyj" async></script><!-- Google tag (gtag.js) for GA4 --><script async src="https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M"></script><script>  window.dataLayer = window.dataLayer || [];  function gtag(){dataLayer.push(arguments);}  gtag('js', new Date());  gtag('config', 'G-GXH0EY936M');</script>  </head><body>  <!-- HEADER INCLUDE -->  <head>  <meta charset="UTF-8" />  <meta name="viewport" content="width=device-width, initial-scale=1" />  </script>  <meta name="description"        content="LEM Building Surveying Ltd. – Professional property surveys across North Wales, Chester, and the North West." /><head>	  <!-- Main CSS -->  <link rel="stylesheet" href="styles.css" />  <!-- CTA colour override for header only -->  <style>    /* Use your “sage” for buttons on charcoal (header) */    .main-nav a.cta {      background-color: var(--sage-grey) !important;      color:       var(--text-dark) !important;    }    .main-nav a.cta:hover {      background-color: var(--light-grey) !important;    }  </style></head>  <!-- Font Awesome -->  <link    rel="stylesheet"    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"    integrity="sha512-RXf+QSDCUqzlgfO2z3lBU9rxO9xWJ6gU5AFVOIGuKz6ZlnbqybwVu6vZP4ylDkKUTnSR5Fctj/6aydcZ4IB3BQ=="    crossorigin="anonymous"    referrerpolicy="no-referrer"  />  <!-- Main CSS -->  <link rel="stylesheet" href="/styles.css" />  <title>LEM Building Surveying Ltd.</title></head><body>  <header>    <div class="header-inner">      <div class="branding">        <a href="/index.html" class="logo-link" aria-label="LEM Building Surveying Ltd home">          <img src="/logo-sticker.png" alt="LEM Building Surveying Ltd Logo" class="logo" />          <span class="site-name">LEM Building Surveying Ltd.</span>        </a>      </div>      <nav class="main-nav" aria-label="Main Navigation">        <ul>          <li><a href="/index.html">Home</a></li>          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>                    <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>        </ul>      </nav>    </div>  </header>  <!-- HERO -->  <section class="hero">    <div class="hero-container">      <h1>Our Property Surveying Services</h1>      <p class="hero-subtitle">Independent, RICS-standard inspections & clear reporting.</p>      <a href="/enquiry.html" class="cta-button hero-contrast">Request a Quote</a>    </div>  </section>  <!-- TABLE OF CONTENTS -->  <nav class="services-toc">    <div class="box-container">      <p><strong>Jump to a service:</strong></p>      <ul class="toc-list">        <li><a href="#rics">RICS Home Surveys</a></li>        <li><a href="#damp">Damp &amp; Timber Reports</a></li>        <li><a href="#measured">Measured Surveys &amp; Floorplans</a></li>        <li><a href="#epc">EPCs with Floorplans</a></li>        <li><a href="#ventilation">Ventilation Assessments</a></li>        <li><a href="#additional">Additional Services</a></li>      </ul>    </div>  </nav>  <!-- SERVICES DETAIL BLOCKS -->  <section class="services-detail">    <!-- RICS Home Surveys -->    <article id="rics" class="service-block">      <div class="box-container">        <h2>RICS Home Surveys – Level 1, 2 & 3</h2>        <p>Choose the depth of inspection that matches your property and risk profile, all in line with the latest <strong>RICS Home Survey Standard</strong>.</p>        <ul class="bullet-list">          <li><strong>Level 1 – Condition Report:</strong> traffic-light overview for newer properties.</li>          <li><strong>Level 2 – HomeBuyer Survey:</strong> most popular pre-purchase report, including photos & advice.</li>          <li><strong>Level 3 – Building Survey:</strong> comprehensive fabric & structural analysis for older or altered homes.</li>        </ul>        <a href="/rics-home-surveys.html" class="inline-link">See full RICS survey guide →</a>      </div>    </article>    <!-- Damp & Timber Reports -->    <article id="damp" class="service-block alt">      <div class="box-container">        <h2>Damp &amp; Timber Reports</h2>        <p>Independent diagnosis of rising damp, condensation, penetrating moisture and timber decay – ideal for mortgage lenders or remedial planning.</p>        <a href="/damp-timber-surveys.html" class="inline-link">Learn more about Damp &amp; Timber Surveys →</a>      </div>    </article>    <!-- Measured Surveys -->    <article id="measured" class="service-block">      <div class="box-container">        <h2>Measured Surveys &amp; Floorplans</h2>        <p>Accurate CAD plans, elevations and sections for extensions, redesigns or documentation. Suitable for homeowners, architects and planning submissions.</p>        <a href="/measured-surveys.html" class="inline-link">See Measured Survey options →</a>      </div>    </article>    <!-- EPCs -->    <article id="epc" class="service-block alt">      <div class="box-container">        <h2>EPCs with Floorplans</h2>        <p>Domestic Energy Performance Certificates combined with high-quality floorplans – perfect for sales listings and lettings compliance.</p>        <a href="/epc-with-floorplans.html" class="inline-link">EPC service details →</a>      </div>    </article>    <!-- Ventilation -->    <article id="ventilation" class="service-block">      <div class="box-container">        <h2>Residential Ventilation Assessments</h2>        <p>Evaluate extractor fans, trickle vents and airflow rates using anemometers. Diagnose condensation and mould root causes.</p>        <a href="/ventilation-assessments.html" class="inline-link">Ventilation Assessment guide →</a>      </div>    </article>    <!-- Additional Services -->    <article id="additional" class="service-block alt">      <div class="box-container">        <h2>Additional Services</h2>        <p>Snagging lists, landlord inspections, planned maintenance schedules, commercial surveys &amp; fire safety assessments available on request.</p>        <a href="/additional-services.html" class="inline-link">Full list of additional services →</a>      </div>    </article>  </section>  <!-- CTA -->  <section class="services-cta">    <div class="box-container">      <h2>Ready to Book or Need Advice?</h2>      <p>Click below to request your tailored quote – most enquiries answered within the hour.</p>      <a href="/enquiry.html" class="cta-button">Request a Quote</a>    </div>  </section>  <!-- STICKY CTA -->  <div class="sticky-cta"><a href="/enquiry.html" class="cta-button">Get a Quote</a></div>  <!-- FOOTER INCLUDE -->  <div id="footer-include"></div>  <!-- Helper scripts -->  <script>    document.addEventListener('DOMContentLoaded', () => {      fetch('/header.html').then(r => r.text()).then(html => {        document.getElementById('header-include').innerHTML = html;      });      fetch('/footer.html').then(r => r.text()).then(html => {        document.getElementById('footer-include').innerHTML = html;      });    });  </script></body></html>
+<html lang="en"><head>  <meta charset="UTF-8" />  <meta name="viewport" content="width=device-width, initial-scale=1.0" />  <title>Property Surveying Services | RICS Surveys, Damp Reports & EPCs | LEM Building Surveying Ltd</title>  <meta name="description" content="Explore the full range of property surveying services from LEM Building Surveying Ltd: RICS Home Surveys, Damp & Timber Reports, Measured Surveys, EPCs, Ventilation Assessments and more across Deeside, Chester & the North West." />  <meta name="keywords" content="RICS Home Survey, Building Survey, Damp Report, Measured Survey, Floorplans, EPC with Floorplan, Ventilation Assessment, Property Surveyor Deeside Chester Flintshire" />  <link rel="stylesheet" href="/styles.css" />  <link rel="icon" href="/favicon.ico" />    <!-- Cookie Consent Mode with Usercentrics --><script src="https://web.cmp.usercentrics.eu/modules/autoblocker.js"></script><script id="usercentrics-cmp" src="https://web.cmp.usercentrics.eu/ui/loader.js" data-settings-id="53YNyaAqMpXqyj" async></script><!-- Google tag (gtag.js) for GA4 --><script async src="https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M"></script><script>  window.dataLayer = window.dataLayer || [];  function gtag(){dataLayer.push(arguments);}  gtag('js', new Date());  gtag('config', 'G-GXH0EY936M');</script>  </head><body>  <!-- HEADER INCLUDE -->  <head>  <meta charset="UTF-8" />  <meta name="viewport" content="width=device-width, initial-scale=1" />  </script>  <meta name="description"        content="LEM Building Surveying Ltd. – Professional property surveys across North Wales, Chester, and the North West." /><head>	  <!-- Main CSS -->  <link rel="stylesheet" href="styles.css" />  <!-- CTA colour override for header only -->  <style>    /* Use your “sage” for buttons on charcoal (header) */    .main-nav a.cta {      background-color: var(--sage-grey) !important;      color:       var(--text-dark) !important;    }    .main-nav a.cta:hover {      background-color: var(--light-grey) !important;    }  </style></head>  <!-- Font Awesome -->  <link    rel="stylesheet"    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"    integrity="sha512-RXf+QSDCUqzlgfO2z3lBU9rxO9xWJ6gU5AFVOIGuKz6ZlnbqybwVu6vZP4ylDkKUTnSR5Fctj/6aydcZ4IB3BQ=="    crossorigin="anonymous"    referrerpolicy="no-referrer"  />  <!-- Main CSS -->  <link rel="stylesheet" href="/styles.css" />  <title>LEM Building Surveying Ltd.</title></head><body>  <header>    <div class="header-inner">      <div class="branding">        <a href="/index.html" class="logo-link" aria-label="LEM Building Surveying Ltd home">          <img src="/logo-sticker.png" alt="LEM Building Surveying Ltd Logo" class="logo" />          <span class="site-name">LEM Building Surveying Ltd.</span>        </a>      </div>      <nav class="main-nav" aria-label="Main Navigation">        <ul>          <li><a href="/index.html">Home</a></li>          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>                    <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>        </ul>      </nav>    </div>  </header>  <!-- HERO -->  <section class="hero">    <div class="hero-container">      <h1>Our Property Surveying Services</h1>      <p class="hero-subtitle">Independent, RICS-standard inspections & clear reporting.</p>      <a href="/enquiry.html" class="cta-button hero-contrast">Request a Quote</a>    </div>  </section>  <!-- TABLE OF CONTENTS -->  <nav class="services-toc">    <div class="box-container">      <p><strong>Jump to a service:</strong></p>      <ul class="toc-list">        <li><a href="#rics">RICS Home Surveys</a></li>        <li><a href="#damp">Damp &amp; Timber Reports</a></li>        <li><a href="#measured">Measured Surveys &amp; Floorplans</a></li>        <li><a href="#epc">EPCs with Floorplans</a></li>        <li><a href="#ventilation">Ventilation Assessments</a></li>        <li><a href="#additional">Additional Services</a></li>      </ul>    </div>  </nav>  <!-- SERVICES DETAIL BLOCKS -->  <section class="services-detail">    <!-- RICS Home Surveys -->    <article id="rics" class="service-block">      <div class="box-container">        <h2>RICS Home Surveys – Level 1, 2 & 3</h2>        <p>Choose the depth of inspection that matches your property and risk profile, all in line with the latest <strong>RICS Home Survey Standard</strong>.</p>        <ul class="bullet-list">          <li><strong>Level 1 – Condition Report:</strong> traffic-light overview for newer properties.</li>          <li><strong>Level 2 – HomeBuyer Survey:</strong> most popular pre-purchase report, including photos & advice.</li>          <li><strong>Level 3 – Building Survey:</strong> comprehensive fabric & structural analysis for older or altered homes.</li>        </ul>        <a href="/rics-home-surveys.html" class="inline-link">See full RICS survey guide →</a>      </div>    </article>    <!-- Damp & Timber Reports -->    <article id="damp" class="service-block alt">      <div class="box-container">        <h2>Damp &amp; Timber Reports</h2>        <p>Independent diagnosis of rising damp, condensation, penetrating moisture and timber decay – ideal for mortgage lenders or remedial planning.</p>        <a href="/damp-timber-surveys.html" class="inline-link">Learn more about Damp &amp; Timber Surveys →</a>      </div>    </article>    <!-- Measured Surveys -->    <article id="measured" class="service-block">      <div class="box-container">        <h2>Measured Surveys &amp; Floorplans</h2>        <p>Accurate CAD plans, elevations and sections for extensions, redesigns or documentation. Suitable for homeowners, architects and planning submissions.</p>        <a href="/measured-surveys.html" class="inline-link">See Measured Survey options →</a>      </div>    </article>    <!-- EPCs -->    <article id="epc" class="service-block alt">      <div class="box-container">        <h2>EPCs with Floorplans</h2>        <p>Domestic Energy Performance Certificates combined with high-quality floorplans – perfect for sales listings and lettings compliance.</p>        <a href="/epc-with-floorplans.html" class="inline-link">EPC service details →</a>      </div>    </article>    <!-- Ventilation -->    <article id="ventilation" class="service-block">      <div class="box-container">        <h2>Residential Ventilation Assessments</h2>        <p>Evaluate extractor fans, trickle vents and airflow rates using anemometers. Diagnose condensation and mould root causes.</p>        <a href="/ventilation-assessments.html" class="inline-link">Ventilation Assessment guide →</a>      </div>    </article>    <!-- Additional Services -->    <article id="additional" class="service-block alt">      <div class="box-container">        <h2>Additional Services</h2>        <p>Snagging lists, landlord inspections, planned maintenance schedules, commercial surveys &amp; fire safety assessments available on request.</p>        <a href="/additional-services.html" class="inline-link">Full list of additional services →</a>      </div>    </article>  </section>  <!-- CTA -->  <section class="services-cta">    <div class="box-container">      <h2>Ready to Book or Need Advice?</h2>      <p>Click below to request your tailored quote – most enquiries answered within the hour.</p>      <a href="/enquiry.html" class="cta-button">Request a Quote</a>    </div>  </section>  <!-- STICKY CTA -->  <div class="sticky-cta"><a href="/enquiry.html" class="cta-button">Get a Quote</a></div>  <!-- FOOTER INCLUDE -->  <div id="footer-include"></div>  <!-- Helper scripts -->  <script>    document.addEventListener('DOMContentLoaded', () => {      fetch('/header.html').then(r => r.text()).then(html => {        document.getElementById('header-include').innerHTML = html;      });      fetch('/footer.html').then(r => r.text()).then(html => {        document.getElementById('footer-include').innerHTML = html;      });    });  </script></body></html>


### PR DESCRIPTION
## Summary
- Consolidated `<head>` in `services.html` with meta tags, stylesheet, Font Awesome, favicon, consent and analytics scripts, and CTA styling.
- Removed nested `<head>`/`<link>` blocks and extraneous header markup so `<body>` starts cleanly with a header include.

## Testing
- `npx vnu-jar services.html` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_689c4482fbb083238c261fd56b8295dd