### PR TITLE
Remove duplicate GA script and unused header fetch

### DIFF
--- a/rics-home-surveys.html
+++ b/rics-home-surveys.html
@@ -395,9 +395,6 @@
   <div id="footer-include"></div>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      fetch('/header.html')
-        .then(r => r.text())
-        .then(html => document.getElementById('header-include').innerHTML = html);
       fetch('/footer.html')
         .then(r => r.text())
         .then(html => document.getElementById('footer-include').innerHTML = html);
@@ -426,15 +423,6 @@
         }
       });
     });
-  </script>
-
-  <!-- Google Tag -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){ dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', 'G-GXH0EY936M');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove duplicate Google Analytics script in `rics-home-surveys.html`
- Drop unused `fetch('/header.html')` include, leaving only footer load

## Testing
- `npx --yes htmlhint rics-home-surveys.html` *(fails: 403 Forbidden)*
- `tidy -q -e rics-home-surveys.html` *(fails: command not found)*
- `curl -I https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_689c40f161088323a906d9d08115a3f0