### PR TITLE
Fix invalid markup in footer contact link

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -7,7 +7,7 @@
       <p>Connah’s Quay, Deeside<br />Flintshire</p>
       <p><strong>T:</strong> <a href="tel:07378732037">07378&nbsp;732&nbsp;037</a><br />
          <strong>E:</strong> <a href="mailto:enquiries@lembuildingsurveying.co.uk">enquiries@lembuildingsurveying.co.uk</a></p>
-         <p></strong> <a href="/contact.html">Contact us</a><br />
+         <p><a href="/contact.html">Contact us</a></p>
       <p class="small">Mon–Fri</p>
       <p class="small">08:30–17:30</p>
     </section>


### PR DESCRIPTION
## Summary
- remove stray closing tag in footer contact section
- wrap "Contact us" link in its own paragraph

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c398f3010832394f424560c637665