### PR TITLE
Add internal links between locations and services

### DIFF
--- a/aldford.html
+++ b/aldford.html
@@ -58,6 +58,8 @@
         <li><strong>Ventilation & Condensation Assessments:</strong> Investigate airflow issues contributing to poor indoor air quality or persistent damp.</li>
         <li><strong>Measured Surveys & Floorplans:</strong> Get accurate drawings for space planning or extension work.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Aldford</a>.</p>
+
 
       <h2>Why Choose LEM Building Surveying?</h2>
       <ul>

--- a/boughton.html
+++ b/boughton.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Ideal for renovations, planning or letting.</li>
         <li><strong>Ventilation & EPC Assessments:</strong> Support with airflow or compliance concerns.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Boughton</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/bretton.html
+++ b/bretton.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Internal layouts and dimensions for redesign, records or planning use.</li>
         <li><strong>EPCs with Floorplans:</strong> Energy Performance Certificate with detailed floorplan included.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Bretton</a>.</p>
+
       <p><a href="/services.html">See all services →</a></p>
 
       <h2>Why Choose LEM?</h2>

--- a/broughton.html
+++ b/broughton.html
@@ -61,6 +61,8 @@
         <li><strong>EPCs with Floorplans:</strong> Combined Energy Performance Certificate and marketing-quality floorplan.</li>
         <li><strong>Residential Ventilation Assessments:</strong> Identifying airflow issues that may be causing condensation, damp or poor air quality.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Broughton</a>.</p>
+
 
       <p><a href="/services.html">View All Services Offered →</a></p>
 

--- a/cheshire.html
+++ b/cheshire.html
@@ -59,6 +59,8 @@
         <li><strong>EPCs with Floorplans:</strong> Perfect for listings, compliance or landlord records.</li>
         <li><strong>Ventilation Reports:</strong> Helpful where mould, condensation or air quality is a concern.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Cheshire</a>.</p>
+
       <p><a href="/services.html">See all services →</a></p>
 
       <h2>Why Use LEM?</h2>

--- a/chester.html
+++ b/chester.html
@@ -59,6 +59,8 @@
         <li><strong>EPCs with Floorplans:</strong> Required for property sales or rentals — includes a marketing-ready floorplan.</li>
         <li><strong>Ventilation Assessments:</strong> Identify airflow, humidity or mould risk issues before they become a problem.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Chester</a>.</p>
+
       <p><a href="/services.html">See full list of services →</a></p>
 
       <h2>Why Choose LEM Building Surveying?</h2>

--- a/christleton.html
+++ b/christleton.html
@@ -58,6 +58,8 @@
         <li><strong>Residential Ventilation Assessments:</strong> Diagnose poor airflow, indoor humidity and condensation risk.</li>
         <li><strong>Measured Floorplans:</strong> Scaled drawings for planning, marketing or renovation.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Christleton</a>.</p>
+
 
       <h2>Why Choose LEM Building Surveying?</h2>
       <ul>

--- a/connahs-quay.html
+++ b/connahs-quay.html
@@ -61,6 +61,8 @@
         <li><strong>EPCs with Floorplans:</strong> Combined Energy Performance Certificate and floorplan—ideal for property listings and compliance.</li>
         <li><strong>Ventilation Assessments:</strong> Help improve indoor air quality and prevent condensation.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Connahs Quay</a>.</p>
+
       <p><a href="/services.html">View Full List of Services →</a></p>
 
       <h2>Why Choose LEM?</h2>

--- a/curzon-park.html
+++ b/curzon-park.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Accurate plans for extensions, valuations, or architectural work.</li>
         <li><strong>Residential Ventilation Assessments:</strong> Checking airflow, condensation risk, and general indoor environment.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Curzon Park</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/deeside.html
+++ b/deeside.html
@@ -58,6 +58,8 @@
         <li><strong>EPCs with Floorplans:</strong> Energy certificates with floorplan included — ideal for letting or resale.</li>
         <li><strong>Ventilation Assessments:</strong> Diagnose condensation, stuffy rooms or poor indoor air quality.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Deeside</a>.</p>
+
 
       <p><a href="/comparison.html">Compare Survey Levels →</a></p>
 

--- a/dobshill.html
+++ b/dobshill.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Floorplans:</strong> Accurate layout drawings for planning, redesign or property records.</li>
         <li><strong>EPCs with Floorplans:</strong> Energy Performance Certificate and visual layout — ideal for listings or compliance.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Dobshill</a>.</p>
+
       <p><a href="/services.html">View all services →</a></p>
 
       <h2>Why LEM Surveying?</h2>

--- a/dodleston.html
+++ b/dodleston.html
@@ -53,6 +53,8 @@
         <li><strong>EPCs with Floorplans:</strong> Combined energy rating and layout plan, ideal for property marketing or lettings.</li>
         <li><strong>Ventilation Assessments:</strong> Identify poor airflow, condensation risks, or persistent damp issues.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Dodleston</a>.</p>
+
       <p><a href="/services.html">View all survey services →</a></p>
 
       <h2>Why Choose LEM?</h2>

--- a/eccleston.html
+++ b/eccleston.html
@@ -58,6 +58,8 @@
         <li><strong>Ventilation & Mould Assessments:</strong> Identify issues affecting air quality, condensation or recurring damp.</li>
         <li><strong>Measured Floorplans:</strong> Scaled drawings for planning, renovation, or space documentation.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Eccleston</a>.</p>
+
 
       <h2>Why Choose LEM Building Surveying?</h2>
       <ul>

--- a/ewloe.html
+++ b/ewloe.html
@@ -60,6 +60,8 @@
         <li><strong>EPCs with Floorplans:</strong> Energy Performance Certificates with full colour floorplans for marketing or compliance.</li>
         <li><strong>Ventilation Assessments:</strong> Expert checks of airflow, humidity and air quality in domestic buildings.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Ewloe</a>.</p>
+
 
       <p><a href="/services.html">View All Services Offered</a></p>
 

--- a/farndon.html
+++ b/farndon.html
@@ -57,6 +57,8 @@
         <li><strong>Damp & Timber Reports:</strong> For targeted damp issues, rot or timber defects.</li>
         <li><strong>EPCs & Floorplans:</strong> Useful for listings, compliance, or planning alterations.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Farndon</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/flint.html
+++ b/flint.html
@@ -58,6 +58,8 @@
         <li><strong>EPCs with Floorplans:</strong> Energy certificate plus floorplan — ideal for letting or selling properties.</li>
         <li><strong>Ventilation Assessments:</strong> Helps identify causes of condensation and poor airflow affecting indoor air quality.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Flint</a>.</p>
+
 
       <p><a href="/comparison.html">Compare Survey Levels →</a></p>
 

--- a/flintshire.html
+++ b/flintshire.html
@@ -59,6 +59,8 @@
         <li><strong>EPCs with Floorplans:</strong> Combined Energy Performance Certificate and marketing-ready layout plans.</li>
         <li><strong>Ventilation Assessments:</strong> Ideal for condensation and indoor air quality concerns.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Flintshire</a>.</p>
+
       <p><a href="/services.html">View all services offered →</a></p>
 
       <h2>Why Choose LEM?</h2>

--- a/gresford.html
+++ b/gresford.html
@@ -52,6 +52,8 @@
         <li><strong>Floorplans & Measured Surveys:</strong> Useful for renovations, documentation or pre-sale preparation.</li>
         <li><strong>Residential Ventilation Checks:</strong> Improve air quality and identify hidden causes of condensation or mould.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Gresford</a>.</p>
+
       <li><a href="/services.html">View Full List of Services</a></li>
 
       <h2>Why Gresford Clients Choose LEM</h2>

--- a/guilden-sutton.html
+++ b/guilden-sutton.html
@@ -58,6 +58,8 @@
         <li><strong>Ventilation Assessments:</strong> Check airflow, air quality and causes of condensation in residential properties.</li>
         <li><strong>Measured Floorplans:</strong> Accurate plans for planning, resale, or extensions.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Guilden Sutton</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/handbridge.html
+++ b/handbridge.html
@@ -59,6 +59,8 @@
         <li><strong>Measured Floorplans:</strong> Scaled drawings for planning, records or renovation purposes.</li>
         <li><strong>Energy & Ventilation Reports:</strong> EPCs and assessments to check air quality or tackle condensation.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Handbridge</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/hawarden.html
+++ b/hawarden.html
@@ -58,6 +58,8 @@
         <li><strong>EPCs with Floorplans:</strong> Energy rating and scaled floorplan combined—ideal for rental listings or marketing.</li>
         <li><strong>Ventilation Assessments:</strong> Evaluate air quality and identify sources of condensation or damp risk.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Hawarden</a>.</p>
+
 
       <p><a href="/services.html">View All Services Offered</a></p>
 

--- a/higher-kinnerton.html
+++ b/higher-kinnerton.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Accurate floorplans for home improvement, extensions or planning.</li>
         <li><strong>EPCs with Floorplans:</strong> Required for sales or lettings — includes an Energy Performance Certificate with layout drawing.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Higher Kinnerton</a>.</p>
+
       <p><a href="/services.html">Explore all services →</a></p>
 
       <h2>Why Choose LEM Building Surveying?</h2>

--- a/holywell.html
+++ b/holywell.html
@@ -61,6 +61,8 @@
         <li><strong>EPCs with Floorplans:</strong> Combined Energy Performance Certificate and marketing-quality floorplan.</li>
         <li><strong>Residential Ventilation Assessments:</strong> Identifying airflow issues that may be causing condensation, damp or poor air quality.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Holywell</a>.</p>
+
 
       <p><a href="/services.html">View All Services Offered →</a></p>
 

--- a/hoole.html
+++ b/hoole.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Floorplans:</strong> Accurate plans for sales, planning or record-keeping.</li>
         <li><strong>EPC & Ventilation Advice:</strong> Help with air quality or energy efficiency concerns.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Hoole</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/huntington.html
+++ b/huntington.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Floorplans:</strong> Useful for extension planning or design purposes.</li>
         <li><strong>Ventilation Assessments:</strong> Improve airflow and reduce the risk of condensation or damp-related issues.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Huntington</a>.</p>
+
 
       <h2>Why Choose LEM Building Surveying?</h2>
       <ul>

--- a/level-1-or-level-2.html
+++ b/level-1-or-level-2.html
@@ -65,7 +65,9 @@
       <p>Still unsure? Liam is happy to help you choose the right survey before you commit.</p>
       <p><strong>Call <a href="tel:07378732037">07378 732037</a> or <a href="/enquiry.html">submit an enquiry</a> to schedule your Level 1 or Level 2 Home Survey today.</strong></p>
       <p>Make the right choice with clarity and confidence.</p>
-    </div>
+
+          <p>Need a <a href="/level-2.html">Level 2 Home Survey in Bretton</a>? See our <a href="/bretton.html">Bretton surveyor page</a> for local insight.</p>
+</div>
   </section>
 
   <!-- FOOTER -->
@@ -84,4 +86,5 @@
     });
   </script>
 </body>
-</html>
+</html
+>

--- a/level-2-or-level-3.html
+++ b/level-2-or-level-3.html
@@ -16,6 +16,7 @@
       <h1>Do I Need a Level 2 or Level 3 Survey?</h1>
       <p>Choose the Right Survey for Your Property with Confidence</p>
       <a href="/enquiry.html" class="cta-button">Request a Quote</a>
+
     </div>
   </section>
 
@@ -73,7 +74,8 @@
         <li><strong>Personal service:</strong> You speak directly to your surveyor</li>
         <li><strong>Local knowledge:</strong> We understand property types and common issues across North Wales and the North West</li>
       </ul>
-    </div>
+          <p>Need a <a href="/level-2.html">Level 2 Home Survey in Bretton</a>? See our <a href="/bretton.html">Bretton surveyor page</a> for local insight.</p>
+</div>
   </section>
 
   <div id="footer-include"></div>
@@ -92,4 +94,5 @@
   });
   </script>
 </body>
-</html>
+</html
+>

--- a/lower-kinnerton.html
+++ b/lower-kinnerton.html
@@ -58,6 +58,8 @@
         <li><strong>Floorplans & Measured Surveys:</strong> Internal measurements for planning, records, or design purposes.</li>
         <li><strong>EPCs with Floorplans:</strong> For selling, letting or compliance.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Lower Kinnerton</a>.</p>
+
       <p><a href="/services.html">View all services →</a></p>
 
       <h2>Why Work With LEM?</h2>

--- a/marford.html
+++ b/marford.html
@@ -52,6 +52,8 @@
         <li><strong>Floorplans & Measured Surveys:</strong> Useful for buyers, planning applications, or renovation work.</li>
         <li><strong>Ventilation Assessments:</strong> Improve air quality, reduce condensation and identify causes of mould.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Marford</a>.</p>
+
       <li><a href="/services.html">View Full List of Services</a></li>
 
       <h2>Why Marford Clients Trust LEM</h2>

--- a/mold.html
+++ b/mold.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Scaled drawings for reconfiguring layouts, planning, or documentation.</li>
         <li><strong>EPCs with Floorplans:</strong> Energy certificate plus digital plan for letting or property marketing.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Mold</a>.</p>
+
       <p><a href="/services.html">View all services offered →</a></p>
 
       <h2>Why Choose LEM for Mold Surveys?</h2>

--- a/new-brighton.html
+++ b/new-brighton.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Accurate measurements for planning, extensions, or space assessments.</li>
         <li><strong>Ventilation Assessments:</strong> Evaluate indoor air quality and resolve condensation problems.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in New Brighton</a>.</p>
+
       <li><a href="/services.html">View All Services Offered</a></li>
 
       <h2>Why Choose LEM Building Surveying?</h2>

--- a/newton.html
+++ b/newton.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys:</strong> Floorplans and spatial layouts for planning or documentation.</li>
         <li><strong>Ventilation Reports:</strong> For condensation, air quality, or mould problems — ideal for buyers or landlords.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Newton</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/north-west-of-england.html
+++ b/north-west-of-england.html
@@ -35,6 +35,8 @@
         <li><strong>Ventilation Assessments:</strong> Diagnose persistent condensation or indoor air issues, especially in tenanted or energy-efficient homes.</li>
         <li><a href="/services.html">View All Services →</a></li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in North West of England</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/northop-hall.html
+++ b/northop-hall.html
@@ -60,6 +60,8 @@
         <li><strong>EPCs & Floorplans:</strong> Ideal for landlords, sellers or planning applications. Includes full digital plan and compliance certificate.</li>
         <li><strong>Ventilation Checks:</strong> Identify poor airflow or hidden moisture risks inside the home.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Northop Hall</a>.</p>
+
 
       <p><a href="/services.html">View All Services Offered</a></p>
 

--- a/northop.html
+++ b/northop.html
@@ -60,6 +60,8 @@
         <li><strong>EPCs & Floorplans:</strong> Great for landlords, sellers or renovation plans.</li>
         <li><strong>Ventilation Checks:</strong> Identify airflow and condensation risks before they become expensive problems.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Northop</a>.</p>
+
 
       <p><a href="/services.html">View All Services Offered</a></p>
 

--- a/oakenholt.html
+++ b/oakenholt.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Accurate internal measurements and layout drawings for planning, compliance or renovation.</li>
         <li><strong>Ventilation Assessments:</strong> Investigate condensation, mould and air flow issues affecting indoor air quality or comfort.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Oakenholt</a>.</p>
+
       <p><a href="/services.html">View all services →</a></p>
 
       <h2>Why Choose LEM?</h2>

--- a/penyffordd.html
+++ b/penyffordd.html
@@ -61,6 +61,8 @@
         <li><strong>EPCs with Floorplans:</strong> Energy Performance Certificates with scaled floorplans for compliance and marketing.</li>
         <li><strong>Residential Ventilation Checks:</strong> Identify risks from poor airflow, condensation or high humidity levels.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Penyffordd</a>.</p>
+
 
       <p><a href="/services.html">View All Services Offered</a></p>
 

--- a/pulford.html
+++ b/pulford.html
@@ -55,6 +55,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Precise internal measurements for extensions or renovation plans.</li>
         <li><strong>Ventilation Reports:</strong> Highlight condensation, airflow and indoor air quality concerns.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Pulford</a>.</p>
+
       <li><a href="/services.html">Explore all available services</a></li>
 
       <h2>Why Choose LEM?</h2>

--- a/queensferry.html
+++ b/queensferry.html
@@ -57,6 +57,8 @@
         <li><strong>Damp & Timber Surveys:</strong> Investigate signs of mould, water ingress, or timber decay. Clear reporting with no pushy sales tactics.</li>
         <li><strong>Measured Surveys & EPCs:</strong> Floorplans and energy certificates available for listings, planning or renovation support.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Queensferry</a>.</p>
+
 
       <h2>Why Clients Choose LEM</h2>
       <ul>

--- a/saighton.html
+++ b/saighton.html
@@ -57,6 +57,8 @@
         <li><strong>Damp & Timber Reports:</strong> Clear diagnosis of visible damp or decay with practical next steps.</li>
         <li><strong>EPCs & Floorplans:</strong> Useful for lettings, listings or future plans.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Saighton</a>.</p>
+
 
       <h2>Why LEM Building Surveying?</h2>
       <ul>

--- a/saltney.html
+++ b/saltney.html
@@ -57,6 +57,8 @@
         <li><strong>Damp & Timber Surveys:</strong> Pinpoint damp, mould or rot issues with expert diagnosis and next steps.</li>
         <li><strong>EPCs with Floorplans:</strong> Energy assessments with internal layout plans — perfect for sales or lettings.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Saltney</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/shotton.html
+++ b/shotton.html
@@ -59,6 +59,8 @@
         <li><strong>Measured Floorplans:</strong> Scaled internal layouts suitable for planning, redesign or documentation.</li>
         <li><strong>Ventilation & Condensation Assessments:</strong> Helpful for landlords or tenants experiencing indoor air quality or mould issues.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Shotton</a>.</p>
+
 
       <h2>Why Choose LEM for Surveys in Shotton?</h2>
       <ul>

--- a/sychdyn.html
+++ b/sychdyn.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Ideal for renovation, documentation or planning submissions. Includes accurate room measurements.</li>
         <li><strong>Ventilation Assessments:</strong> Check internal airflow and condensation issues, particularly useful in older or energy-efficient homes.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Sychdyn</a>.</p>
+
       <li><a href="/services.html">View All Services Offered</a></li>
 
       <h2>Why Choose LEM Building Surveying?</h2>

--- a/tarporley.html
+++ b/tarporley.html
@@ -58,6 +58,8 @@
         <li><strong>Floorplans & Measured Surveys:</strong> Accurate drawings for extensions, documentation, or space planning.</li>
         <li><strong>Ventilation Surveys:</strong> Assess airflow and condensation risk in traditional or energy-efficient homes.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Tarporley</a>.</p>
+
 
       <h2>Why Tarporley Clients Choose LEM</h2>
       <ul>

--- a/tarvin.html
+++ b/tarvin.html
@@ -58,6 +58,8 @@
         <li><strong>EPCs with Floorplans:</strong> Energy assessments plus marketing-ready layout plans — perfect for lettings and sales listings.</li>
         <li><strong>Ventilation Assessments:</strong> Identify condensation, mould or poor airflow risks and recommend appropriate improvements.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Tarvin</a>.</p>
+
 
       <p><a href="/services.html">View Full Range of Services →</a></p>
 

--- a/tattenhall.html
+++ b/tattenhall.html
@@ -57,6 +57,8 @@
         <li><strong>Damp & Timber Inspections:</strong> Identify condensation, dampness, or decay — often used for isolated defects or pre-sale due diligence.</li>
         <li><strong>Measured Floorplans & EPCs:</strong> Useful for estate marketing, planning, or energy compliance.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Tattenhall</a>.</p>
+
 
       <h2>Why Choose LEM for Tattenhall?</h2>
       <ul>

--- a/understanding-your-survey-report.html
+++ b/understanding-your-survey-report.html
@@ -70,7 +70,9 @@
       <h2>Ready to Book?</h2>
       <p>Call Liam on <a href="tel:07378732037">07378 732037</a> or <a href="/enquiry.html">submit a quick enquiry</a> to get started.</p>
       <p><strong>Know exactly what you’re buying—and what to do about it.</strong></p>
-    </div>
+
+          <p>Need a <a href="/level-2.html">Level 2 Home Survey in Bretton</a>? See our <a href="/bretton.html">Bretton surveyor page</a> for local insight.</p>
+</div>
   </section>
 
   <!-- Shared Footer -->
@@ -91,4 +93,5 @@
     });
   </script>
 </body>
-</html>
+</html
+>

--- a/vicars-cross.html
+++ b/vicars-cross.html
@@ -58,6 +58,8 @@
         <li><strong>Floorplans & Measured Surveys:</strong> Useful for renovation, marketing or compliance.</li>
         <li><strong>Ventilation Reports:</strong> Identify airflow issues contributing to condensation or poor indoor air quality.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Vicars Cross</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/waverton.html
+++ b/waverton.html
@@ -58,6 +58,8 @@
         <li><strong>Ventilation Assessments:</strong> Identify causes of condensation and poor airflow in older homes or problem rooms.</li>
         <li><strong>Measured Floorplans:</strong> Accurate internal layouts for planning, letting, or refurbishment.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Waverton</a>.</p>
+
 
       <h2>Why Choose LEM?</h2>
       <ul>

--- a/westminster-park.html
+++ b/westminster-park.html
@@ -58,6 +58,8 @@
         <li><strong>Measured Surveys & Floorplans:</strong> Accurate layout drawings for extensions, planning or valuation work.</li>
         <li><strong>Ventilation Assessments:</strong> Indoor air quality and airflow assessments to prevent damp and mould issues.</li>
       </ul>
+      <p>Learn more about our <a href="/rics-home-surveys.html">RICS Home Surveys</a>, including the <a href="/level-2.html">Level 2 Home Survey in Westminster Park</a>.</p>
+
 
       <h2>Why Work with LEM?</h2>
       <ul>

--- a/what-a-rics-survey-can-reveal.html
+++ b/what-a-rics-survey-can-reveal.html
@@ -16,6 +16,7 @@
     <div class="hero-container">
       <h1>What a RICS Survey Can Reveal Before You Buy</h1>
       <p>Hidden Problems, Informed Decisions, and Peace of Mind</p>
+
     </div>
   </section>
 
@@ -70,7 +71,8 @@
         <p>Call Liam at <a href="tel:07378732037">07378 732037</a> for expert guidance or to book your RICS Home Survey today.</p>
         <a href="/enquiry.html" class="cta-button">Request a Quote</a>
       </div>
-    </div>
+          <p>Need a <a href="/level-2.html">Level 2 Home Survey in Bretton</a>? See our <a href="/bretton.html">Bretton surveyor page</a> for local insight.</p>
+</div>
   </section>
 
   <div id="footer-include"></div>
@@ -88,4 +90,5 @@
   </script>
 
 </body>
-</html>
+</html
+>


### PR DESCRIPTION
## Summary
- Link each location page to RICS Home Surveys and Level 2 service with location-specific anchor text
- Add cross-links from blog posts to Level 2 service page and Bretton location page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c71b461fc8323ace0e9dba669d219