### PR TITLE
Revamp navigation with active page state

### DIFF
--- a/damp-mould-surveys.html
+++ b/damp-mould-surveys.html
@@ -23,8 +23,11 @@
       <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
       <ul class="nav-links">
           <li><a href="/index.html">Home</a></li>
-          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
-          
+          <li><a href="/services.html">Services</a></li>
+          <li><a href="/local-surveys.html">Areas We Cover</a></li>
+          <li><a href="/comparison.html">Pricing</a></li>
+          <li><a href="/testimonials.html">Testimonials</a></li>
+          <li><a href="/contact.html">Contact</a></li>
           <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
         </ul>
       </nav>

--- a/header.html
+++ b/header.html
@@ -52,8 +52,11 @@
       <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
       <ul class="nav-links">
           <li><a href="/index.html">Home</a></li>
-          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
-          
+          <li><a href="/services.html">Services</a></li>
+          <li><a href="/local-surveys.html">Areas We Cover</a></li>
+          <li><a href="/comparison.html">Pricing</a></li>
+          <li><a href="/testimonials.html">Testimonials</a></li>
+          <li><a href="/contact.html">Contact</a></li>
           <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,12 @@
       <nav class="main-nav" aria-label="Main Navigation">
         <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
         <ul class="nav-links">
-          <li><a href="/index.html" aria-current="page">Home</a></li>
-          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
-          
+          <li><a href="/index.html">Home</a></li>
+          <li><a href="/services.html">Services</a></li>
+          <li><a href="/local-surveys.html">Areas We Cover</a></li>
+          <li><a href="/comparison.html">Pricing</a></li>
+          <li><a href="/testimonials.html">Testimonials</a></li>
+          <li><a href="/contact.html">Contact</a></li>
           <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
         </ul>
       </nav>

--- a/local-surveys.html
+++ b/local-surveys.html
@@ -8,6 +8,7 @@
   <meta name="keywords" content="home surveys, damp surveys, building surveys, Flint, Buckley, Mold, Connahs Quay, Broughton, Saltney, Hawarden, Ewloe, Northop Hall, Northop, Oakenholt, Shotton, Queensferry, Tarporley, Waverton, Hoole, Boughton, Vicars Cross, property survey, LEM Building Surveying">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="index, follow">
+  <link rel="stylesheet" href="/styles.css" />
   
   <!-- Open Graph Tags -->
   <meta property="og:title" content="Local Home & Building Surveys | LEM Building Surveying Ltd">
@@ -67,25 +68,25 @@
   <style>
     /* Basic Reset & Responsive Layout */
     body { font-family: Arial, sans-serif; margin: 0; padding: 0; line-height: 1.6; }
-    header { background: #005a9c; color: #fff; padding: 20px; text-align: center; }
-    nav { background: #333; padding: 10px; text-align: center; }
-    nav a { color: #fff; text-decoration: none; margin: 0 10px; }
-    nav a:hover { text-decoration: underline; }
+    .page-header { background: #005a9c; color: #fff; padding: 20px; text-align: center; }
+    .area-nav { background: #333; padding: 10px; text-align: center; }
+    .area-nav a { color: #fff; text-decoration: none; margin: 0 10px; }
+    .area-nav a:hover { text-decoration: underline; }
     section { padding: 20px; border-bottom: 1px solid #ddd; }
     section:last-of-type { border-bottom: none; }
     h2 { color: #005a9c; }
-    footer { background: #333; color: #fff; text-align: center; padding: 10px; }
     /* For anchor offset when linking from nav (optional) */
     .anchor { display: block; position: relative; top: -80px; visibility: hidden; }
   </style>
 </head>
 <body>
-  <header>
+  <div id="header-include"></div>
+  <header class="page-header">
     <h1>Local Home & Building Surveys</h1>
     <p>Expert Property Assessments by LEM Building Surveying Ltd</p>
   </header>
-  
-  <nav>
+
+  <nav class="area-nav">
     <a href="#flint">Flint</a>
     <a href="#buckley">Buckley</a>
     <a href="#mold">Mold</a>
@@ -250,8 +251,24 @@
     <p><strong>Contact:</strong> Call 07378 732037 or email <a href="mailto:enquiries@lembuildingsurveying.co.uk">enquiries@lembuildingsurveying.co.uk</a></p>
   </section>
   
-  <footer>
-    <p>&copy; 2025 LEM Building Surveying Ltd. All rights reserved.</p>
-  </footer>
+  <div id="footer-include"></div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      fetch('/header.html')
+        .then(r => r.text())
+        .then(html => {
+          document.getElementById('header-include').innerHTML = html;
+          const s = document.createElement('script');
+          s.src = '/nav.js';
+          document.body.appendChild(s);
+        })
+        .catch(err => console.error('Header include failed:', err));
+
+      fetch('/footer.html')
+        .then(r => r.text())
+        .then(html => document.getElementById('footer-include').innerHTML = html)
+        .catch(err => console.error('Footer include failed:', err));
+    });
+  </script>
 </body>
 </html>

--- a/nav.js
+++ b/nav.js
@@ -7,6 +7,14 @@
       navLinks.classList.toggle('nav-open');
       navToggle.classList.toggle('open');
     });
+
+    var path = window.location.pathname;
+    navLinks.querySelectorAll('a').forEach(function(link){
+      var href = link.getAttribute('href');
+      if (href === path || (path === '/' && href === '/index.html')) {
+        link.setAttribute('aria-current', 'page');
+      }
+    });
   }
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', setup);

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,28 +1,63 @@
-<h1>Privacy Policy</h1>
-<p>Last updated: 16 May 2025</p>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy | LEM Building Surveying Ltd</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <div id="header-include"></div>
 
-<h2>1. Who we are</h2>
-<p>LEM Building Surveying Ltd (“we”, “us”)…</p>
+  <main class="box-container">
+    <h1>Privacy Policy</h1>
+    <p>Last updated: 16 May 2025</p>
 
-<h2>2. What data we collect</h2>
-<ul>
-  <li>Name, email, phone (via enquiry form)</li>
-  <li>IP address and behavior (via Google Analytics)</li>
-  <li>Cookies for site performance</li>
-</ul>
+    <h2>1. Who we are</h2>
+    <p>LEM Building Surveying Ltd (“we”, “us”)…</p>
 
-<h2>3. How we use your data</h2>
-<p>To reply to your enquiry, improve our website, send you quotes.</p>
+    <h2>2. What data we collect</h2>
+    <ul>
+      <li>Name, email, phone (via enquiry form)</li>
+      <li>IP address and behavior (via Google Analytics)</li>
+      <li>Cookies for site performance</li>
+    </ul>
 
-<h2>4. Who we share it with</h2>
-<p>Mailing-list provider Mailchimp, Google Analytics, our accountant.</p>
+    <h2>3. How we use your data</h2>
+    <p>To reply to your enquiry, improve our website, send you quotes.</p>
 
-<h2>5. Data retention</h2>
-<p>Your enquiry data is kept for up to 2 years, unless you ask us to delete it.</p>
+    <h2>4. Who we share it with</h2>
+    <p>Mailing-list provider Mailchimp, Google Analytics, our accountant.</p>
 
-<h2>6. Your rights</h2>
-<p>Access, correction, deletion — email enquiries@lembuildingsurveying.co.uk</p>
+    <h2>5. Data retention</h2>
+    <p>Your enquiry data is kept for up to 2 years, unless you ask us to delete it.</p>
 
-<h2>7. Contact & complaints</h2>
-<p>For questions: enquiries@lembuildingsurveying.co.uk.  
-You can lodge a complaint with the ICO: https://ico.org.uk</p>
+    <h2>6. Your rights</h2>
+    <p>Access, correction, deletion — email enquiries@lembuildingsurveying.co.uk</p>
+
+    <h2>7. Contact & complaints</h2>
+    <p>For questions: enquiries@lembuildingsurveying.co.uk.<br />
+    You can lodge a complaint with the ICO: https://ico.org.uk</p>
+  </main>
+
+  <div id="footer-include"></div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      fetch('/header.html')
+        .then(r => r.text())
+        .then(html => {
+          document.getElementById('header-include').innerHTML = html;
+          const s = document.createElement('script');
+          s.src = '/nav.js';
+          document.body.appendChild(s);
+        })
+        .catch(err => console.error('Header include failed:', err));
+
+      fetch('/footer.html')
+        .then(r => r.text())
+        .then(html => document.getElementById('footer-include').innerHTML = html)
+        .catch(err => console.error('Footer include failed:', err));
+    });
+  </script>
+</body>
+</html>

--- a/rics-home-surveys.html
+++ b/rics-home-surveys.html
@@ -107,8 +107,11 @@
       <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
       <ul class="nav-links">
           <li><a href="/index.html">Home</a></li>
-          <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
-          
+          <li><a href="/services.html">Services</a></li>
+          <li><a href="/local-surveys.html">Areas We Cover</a></li>
+          <li><a href="/comparison.html">Pricing</a></li>
+          <li><a href="/testimonials.html">Testimonials</a></li>
+          <li><a href="/contact.html">Contact</a></li>
           <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
         </ul>
       </nav>

--- a/testimonials.html
+++ b/testimonials.html
@@ -1,36 +1,70 @@
-<!-- testimonials.html -->
-<section class="testimonial-section">
-  <div class="testimonial-slider-wrapper">
-    <h2>What Our Clients Say</h2>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Testimonials | LEM Building Surveying Ltd</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <div id="header-include"></div>
 
-    <button class="slider-arrow prev" aria-label="Previous testimonial">‹</button>
+  <main>
+    <section class="testimonial-section">
+      <div class="testimonial-slider-wrapper">
+        <h2>What Our Clients Say</h2>
 
-    <div class="testimonial-slider">
-      <blockquote class="testimonial">
-        <div class="stars">★★★★★</div>
-        <p>
-          “We used Liam to carry out a Level 2 Survey on a property we are purchasing. We found him very responsive, professional and knowledgeable. Liam highlighted issues without frightening us, offering advice on how to move forward. Would highly recommend him.”
-        </p>
-        <footer>— Lindsey M.</footer>
-      </blockquote>
+        <button class="slider-arrow prev" aria-label="Previous testimonial">‹</button>
 
-      <blockquote class="testimonial">
-        <div class="stars">★★★★★</div>
-        <p>
-          “LEM provided an excellent service from start to finish. His report was clear and explained everything simply and with enough detail for me to make informed choices. I would recommend LEM to anyone needing Building Surveying services.”
-        </p>
-        <footer>— Chris S.</footer>
-      </blockquote>
+        <div class="testimonial-slider">
+          <blockquote class="testimonial">
+            <div class="stars">★★★★★</div>
+            <p>
+              “We used Liam to carry out a Level 2 Survey on a property we are purchasing. We found him very responsive, professional and knowledgeable. Liam highlighted issues without frightening us, offering advice on how to move forward. Would highly recommend him.”
+            </p>
+            <footer>— Lindsey M.</footer>
+          </blockquote>
 
-      <blockquote class="testimonial">
-        <div class="stars">★★★★★</div>
-        <p>
-          “Liam was fantastic—professional, efficient, and really knowledgeable. He explained everything clearly, which made the whole process much easier. I’d definitely recommend LEM Building Surveying to anyone needing EPCs, floorplans, or a property survey. A smooth and stress-free experience from start to finish!”
-        </p>
-        <footer>— Helen H.</footer>
-      </blockquote>
-    </div>
+          <blockquote class="testimonial">
+            <div class="stars">★★★★★</div>
+            <p>
+              “LEM provided an excellent service from start to finish. His report was clear and explained everything simply and with enough detail for me to make informed choices. I would recommend LEM to anyone needing Building Surveying services.”
+            </p>
+            <footer>— Chris S.</footer>
+          </blockquote>
 
-    <button class="slider-arrow next" aria-label="Next testimonial">›</button>
-  </div>
-</section>
+          <blockquote class="testimonial">
+            <div class="stars">★★★★★</div>
+            <p>
+              “Liam was fantastic—professional, efficient, and really knowledgeable. He explained everything clearly, which made the whole process much easier. I’d definitely recommend LEM Building Surveying to anyone needing EPCs, floorplans, or a property survey. A smooth and stress-free experience from start to finish!”
+            </p>
+            <footer>— Helen H.</footer>
+          </blockquote>
+        </div>
+
+        <button class="slider-arrow next" aria-label="Next testimonial">›</button>
+      </div>
+    </section>
+  </main>
+
+  <div id="footer-include"></div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      fetch('/header.html')
+        .then(r => r.text())
+        .then(html => {
+          document.getElementById('header-include').innerHTML = html;
+          const s = document.createElement('script');
+          s.src = '/nav.js';
+          document.body.appendChild(s);
+        })
+        .catch(err => console.error('Header include failed:', err));
+
+      fetch('/footer.html')
+        .then(r => r.text())
+        .then(html => document.getElementById('footer-include').innerHTML = html)
+        .catch(err => console.error('Footer include failed:', err));
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Expand header navigation with Services, Areas We Cover, Pricing, Testimonials, Contact and Get a Quote CTA
- Highlight the current page via `aria-current` using nav.js
- Normalize standalone pages like Areas We Cover and Privacy Policy to use shared header/footer includes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c728147a08323a2e6b6d4e29222b4