### PR TITLE
Resolve header navigation merge conflict

### DIFF
--- a/header.html
+++ b/header.html
@@ -11,32 +11,33 @@
 <header>
   <div class="header-inner">
     <div class="branding">
-      <a href="/index.html" class="logo-link" aria-label="LEM Building Surveying Ltd home">
-        <img src="/logo-sticker.png" alt="LEM Building Surveying Ltd Logo" class="logo" />
+      <a
+        href="/index.html"
+        class="logo-link"
+        aria-label="LEM Building Surveying Ltd home"
+      >
+        <img
+          src="/logo-sticker.png"
+          alt="LEM Building Surveying Ltd Logo"
+          class="logo"
+        />
         <span class="site-name">LEM Building Surveying Ltd.</span>
       </a>
     </div>
     <nav class="main-nav" aria-label="Main Navigation">
-      <button class="nav-toggle" aria-label="Toggle menu"><span></span><span></span><span></span></button>
+      <button class="nav-toggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
       <ul class="nav-links">
- <<<<<<< codex/optimize-document-structure-and-meta-sharing
         <li><a href="/index.html">Home</a></li>
         <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
+        <li><a href="/services.html">Services</a></li>
+        <li><a href="/local-surveys.html">Areas We Cover</a></li>
+        <li><a href="/comparison.html">Pricing</a></li>
+        <li><a href="/testimonials.html">Testimonials</a></li>
+        <li><a href="/contact.html">Contact</a></li>
         <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
       </ul>
     </nav>
   </div>
 </header>
-=======
-          <li><a href="/index.html">Home</a></li>
-          <li><a href="/services.html">Services</a></li>
-          <li><a href="/local-surveys.html">Areas We Cover</a></li>
-          <li><a href="/comparison.html">Pricing</a></li>
-          <li><a href="/testimonials.html">Testimonials</a></li>
-          <li><a href="/contact.html">Contact</a></li>
-          <li><a href="/enquiry.html" class="cta">Get a Quote</a></li>
-        </ul>
-      </nav>
-    </div>
-  </header>
- >>>>>>> main


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from `header.html`
- expand navigation list with links to services, coverage areas, pricing, testimonials, contact, and RICS Home Surveys

## Testing
- `npx htmlhint header.html` *(fails: Doctype must be declared before any non-comment content)*
- `npx prettier -c header.html`
- `python -m http.server 8000 &` `curl -I http://localhost:8000/header.html`


------
https://chatgpt.com/codex/tasks/task_b_689cb52ddaf88323b491c4a1c87f2a60