### PR TITLE
Load Trustindex widget after testimonials

### DIFF
--- a/about.html
+++ b/about.html
@@ -156,11 +156,17 @@
         document.addEventListener("DOMContentLoaded", () => {
           fetch("/testimonials.html")
             .then((res) => res.text())
-            .then(
-              (html) =>
-                (document.getElementById("testimonials-include").innerHTML =
-                  html),
-            )
+            .then((html) => {
+              const container = document.getElementById("testimonials-include");
+              container.innerHTML = html;
+
+              const script = document.createElement("script");
+              script.src =
+                "https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7";
+              script.async = true;
+              script.defer = true;
+              container.appendChild(script);
+            })
             .catch((err) => console.error("Testimonials include failed:", err));
         });
       </script>

--- a/rics-home-surveys.html
+++ b/rics-home-surveys.html
@@ -561,11 +561,17 @@
       document.addEventListener("DOMContentLoaded", () => {
         fetch("/testimonials.html")
           .then((res) => res.text())
-          .then(
-            (html) =>
-              (document.getElementById("testimonials-include").innerHTML =
-                html),
-          )
+          .then((html) => {
+            const container = document.getElementById("testimonials-include");
+            container.innerHTML = html;
+
+            const script = document.createElement("script");
+            script.src =
+              "https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7";
+            script.async = true;
+            script.defer = true;
+            container.appendChild(script);
+          })
           .catch((err) => console.error("Testimonials include failed:", err));
       });
     </script>


### PR DESCRIPTION
## Summary
- Append Trustindex loader script after fetching testimonial HTML in about and rics-home-surveys pages so the widget initializes.

## Testing
- `npm test` *(fails: no such file or directory, open '/workspace/cozy-daffodil-f4598c/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_689ed341df0c832380b89ced8d9a1355