### PR TITLE
Add full testimonials page and snippet include

### DIFF
--- a/about.html
+++ b/about.html
@@ -154,7 +154,7 @@
       <div id="testimonials-include"></div>
       <script>
         document.addEventListener("DOMContentLoaded", () => {
-          fetch("/testimonials.html")
+          fetch("/testimonials-snippet.html")
             .then((res) => res.text())
             .then((html) => {
               const container = document.getElementById("testimonials-include");

--- a/rics-home-surveys.html
+++ b/rics-home-surveys.html
@@ -559,7 +559,7 @@
     <div id="testimonials-include"></div>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        fetch("/testimonials.html")
+        fetch("/testimonials-snippet.html")
           .then((res) => res.text())
           .then((html) => {
             const container = document.getElementById("testimonials-include");

--- a/testimonials-snippet.html
+++ b/testimonials-snippet.html
@@ -1,0 +1,1 @@
+<div class="ti-widget ti-goog"></div>

--- a/testimonials.html
+++ b/testimonials.html
@@ -1,2 +1,18 @@
-<div class="ti-widget ti-goog"></div>
-
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Testimonials | LEM Building Surveying Ltd</title>
+    <meta name="description" content="What our clients say about LEM Building Surveying Ltd." />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div id="header-include"></div>
+    <main>
+      <div class="ti-widget ti-goog"></div>
+    </main>
+    <div id="footer-include"></div>
+    <script src="/nav.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Create `testimonials-snippet.html` containing only the TrustIndex widget markup.
- Add full `testimonials.html` page with standard layout and TrustIndex widget.
- Update `about.html` and `rics-home-surveys.html` to fetch the new snippet.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I http://localhost:8000/testimonials.html`


------
https://chatgpt.com/codex/tasks/task_b_689ed4ff23088323b7b3855d86e8a6e7