### PR TITLE
Expose global TrustIndex loader and use on testimonials sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -159,13 +159,7 @@
             .then((html) => {
               const container = document.getElementById("testimonials-include");
               container.innerHTML = html;
-
-              const script = document.createElement("script");
-              script.src =
-                "https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7";
-              script.async = true;
-              script.defer = true;
-              container.appendChild(script);
+              window.loadTrustIndex();
             })
             .catch((err) => console.error("Testimonials include failed:", err));
         });

--- a/nav.js
+++ b/nav.js
@@ -31,6 +31,9 @@
     document.head.appendChild(s);
   }
 
+  // Expose globally so other pages can trigger TrustIndex loading
+  window.loadTrustIndex = loadTrustIndex;
+
   function setupNav(){
     var navToggle = document.querySelector('.nav-toggle');
     var navLinks = document.querySelector('.nav-links');

--- a/rics-home-surveys.html
+++ b/rics-home-surveys.html
@@ -558,23 +558,17 @@
     <!-- TESTIMONIALS -->
     <div id="testimonials-include"></div>
     <script>
-      document.addEventListener("DOMContentLoaded", () => {
-        fetch("/testimonials-snippet.html")
-          .then((res) => res.text())
-          .then((html) => {
-            const container = document.getElementById("testimonials-include");
-            container.innerHTML = html;
-
-            const script = document.createElement("script");
-            script.src =
-              "https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7";
-            script.async = true;
-            script.defer = true;
-            container.appendChild(script);
-          })
-          .catch((err) => console.error("Testimonials include failed:", err));
-      });
-    </script>
+        document.addEventListener("DOMContentLoaded", () => {
+          fetch("/testimonials-snippet.html")
+            .then((res) => res.text())
+            .then((html) => {
+              const container = document.getElementById("testimonials-include");
+              container.innerHTML = html;
+              window.loadTrustIndex();
+            })
+            .catch((err) => console.error("Testimonials include failed:", err));
+        });
+      </script>
     <!-- AREAS WE COVER -->
     <section class="home-areas improved-areas">
       <div class="box-container">


### PR DESCRIPTION
## Summary
- expose `loadTrustIndex` on `window` so pages can reuse a single TrustIndex loader
- reuse global `loadTrustIndex` in About and RICS Home Surveys pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689ed8bad3f48323ae3236d6b8a7cdae