### PR TITLE
Add TrustIndex testimonials widgets across site

### DIFF
--- a/about.html
+++ b/about.html
@@ -151,19 +151,11 @@
         </div>
       </section>
       <!-- TESTIMONIALS -->
-      <div id="testimonials-include"></div>
-      <script>
-        document.addEventListener("DOMContentLoaded", () => {
-          fetch("/testimonials-snippet.html")
-            .then((res) => res.text())
-            .then((html) => {
-              const container = document.getElementById("testimonials-include");
-              container.innerHTML = html;
-              window.loadTrustIndex();
-            })
-            .catch((err) => console.error("Testimonials include failed:", err));
-        });
-      </script>
+      <section class="section" id="testimonials">
+        <h2>Client Testimonials</h2>
+        <div class="ti-widget ti-goog"></div>
+        <script src="https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7" async defer></script>
+      </section>
       <!-- SERVICE AREA DROPDOWN -->
       <section class="home-areas improved-areas">
         <div class="box-container">

--- a/index.html
+++ b/index.html
@@ -309,6 +309,7 @@
       <section class="section" id="testimonials">
         <h2>Client Testimonials</h2>
         <div class="ti-widget ti-goog"></div>
+        <script src="https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7" async defer></script>
       </section>
       <!-- QUICK NAV -->
       <nav aria-label="Page contents" class="quick-nav jump-to">

--- a/testimonials.html
+++ b/testimonials.html
@@ -13,6 +13,7 @@
       <section class="testimonial-section">
         <h1>Client Testimonials</h1>
         <div class="ti-widget ti-goog"></div>
+        <script src="https://cdn.trustindex.io/loader.js?f82e0f551228447e6c06f9b86c7" async defer></script>
       </section>
     </main>
     <div id="footer-include"></div>


### PR DESCRIPTION
## Summary
- Embed TrustIndex loader script after testimonial widgets on home, about, and testimonials pages
- Replace dynamic testimonial include on About page with static section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689ef2d28fb0832399165d8fed1abc00