### PR TITLE
Fix enquiry page layout and header include

### DIFF
--- a/enquiry.html
+++ b/enquiry.html
@@ -1,151 +1,203 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <html lang="en">
-<head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Request a Property Survey | Get a Quote | LEM Building Surveying Ltd</title>
-<meta content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West." name="description"/>
-<meta content="Request Building Survey Quote, Property Survey Form, RICS Survey Enquiry, Damp Survey Quote, Floorplan Survey Deeside Chester North West" name="keywords"/>
-<link href="https://www.lembuildingsurveying.co.uk/enquiry" rel="canonical"/>
-<meta content="Request a Property Survey | Get a Quote | LEM Building Surveying Ltd" property="og:title"/>
-<meta content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West." property="og:description"/>
-<meta content="https://www.lembuildingsurveying.co.uk/enquiry" property="og:url"/>
-<meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" property="og:image"/>
-<meta content="summary_large_image" name="twitter:card"/>
-<meta content="Request a Property Survey | Get a Quote | LEM Building Surveying Ltd" name="twitter:title"/>
-<meta content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West." name="twitter:description"/>
-<meta content="https://www.lembuildingsurveying.co.uk/enquiry" name="twitter:url"/>
-<meta content="https://www.lembuildingsurveying.co.uk/logo-sticker.png" name="twitter:image"/>
-<link href="/styles.css" rel="stylesheet">
-<!-- Google tag (gtag.js) -->
-<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-GXH0EY936M');
-  </script>
-</link></head>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const form = document.querySelector('.enquiry-form');   /* or .contact-form */
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const data = new FormData(form);
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Request a Property Survey | Get a Quote | LEM Building Surveying Ltd</title>
+    <meta
+      content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West."
+      name="description"
+    />
+    <meta
+      content="Request Building Survey Quote, Property Survey Form, RICS Survey Enquiry, Damp Survey Quote, Floorplan Survey Deeside Chester North West"
+      name="keywords"
+    />
+    <link rel="canonical" href="https://www.lembuildingsurveying.co.uk/enquiry" />
+    <meta
+      property="og:title"
+      content="Request a Property Survey | Get a Quote | LEM Building Surveying Ltd"
+    />
+    <meta
+      property="og:description"
+      content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West."
+    />
+    <meta
+      property="og:url"
+      content="https://www.lembuildingsurveying.co.uk/enquiry"
+    />
+    <meta
+      property="og:image"
+      content="https://www.lembuildingsurveying.co.uk/logo-sticker.png"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Request a Property Survey | Get a Quote | LEM Building Surveying Ltd"
+    />
+    <meta
+      name="twitter:description"
+      content="Submit your property details to request a free, no-obligation quote for a building survey, damp report, EPC, or floorplan. Serving Deeside, Chester &amp; the North West."
+    />
+    <meta
+      name="twitter:url"
+      content="https://www.lembuildingsurveying.co.uk/enquiry"
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.lembuildingsurveying.co.uk/logo-sticker.png"
+    />
+    <!-- Preconnect & Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;family=Open+Sans:wght@400;600&amp;display=swap"
+      rel="stylesheet"
+    />
+    <!-- Main stylesheet -->
+    <link rel="stylesheet" href="/styles.css" />
+    <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+      integrity="sha512-RXf+QSDCUqzlgfO2z3lBU9rxO9xWJ6gU5AFVOIGuKz6ZlnbqybwVu6vZP4ylDkKUTnSR5Fctj/6aydcZ4IB3BQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <!-- Usercentrics & GA4 -->
+    <script src="https://web.cmp.usercentrics.eu/modules/autoblocker.js"></script>
+    <script
+      id="usercentrics-cmp"
+      src="https://web.cmp.usercentrics.eu/ui/loader.js"
+      data-settings-id="53YNyaAqMpXqyj"
+      async
+    ></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-GXH0EY936M"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-GXH0EY936M");
+    </script>
+  </head>
+  <body>
+    <div id="header-include"></div>
 
-    const resp = await fetch('https://formspree.io/f/xzzdqqqz', {
-      method: 'POST',
-      body: data,
-      headers: { 'Accept': 'application/json' }
-    });
+    <!-- ENQUIRY PAGE -->
+    <section class="enquiry-page">
+      <div class="box-container">
+        <h1>Request a Property Survey</h1>
+        <p>
+          Complete the form below and Liam will be in touch to confirm details
+          or provide a tailored quote—no obligation.
+        </p>
+        <!-- Formspree: _next ensures redirect after successful send -->
+        <form
+          action="https://formspree.io/f/xzzdqqqz"
+          class="enquiry-form"
+          method="POST"
+        >
+          <input
+            name="_next"
+            type="hidden"
+            value="https://www.lembuildingsurveying.co.uk/thank-you.html"
+          />
+          <label for="name">Full Name:</label>
+          <input id="name" name="name" required type="text" />
 
-    if (resp.ok) {
-      /* fire Google-Ads conversion before leaving */
-      gtag('event', 'conversion', { send_to: 'AW-XXXXXXXXXX/AbCdEFgHiJk' });
-      window.location = '/thank-you.html';
-    } else {
-      alert('Sorry, something went wrong. Please email us directly.');
-    }
-  });
-});
-</script>
-<body>
-<!-- Shared Header -->
-<head>
-<meta charset="utf-8">
-<meta content="width=device-width, initial-scale=1" name="viewport">
+          <label for="email">Email Address:</label>
+          <input id="email" name="email" required type="email" />
 
-<meta content="LEM Building Surveying Ltd. – Professional property surveys across North Wales, Chester, and the North West." name="description">
-<head>
-<!-- Main CSS -->
-<link href="styles.css" rel="stylesheet"/>
-<!-- CTA colour override for header only -->
-<style>
-    /* Use your “sage” for buttons on charcoal (header) */
-    .main-nav a.cta {
-      background-color: var(--sage-grey) !important;
-      color:       var(--text-dark) !important;
-    }
-    .main-nav a.cta:hover {
-      background-color: var(--light-grey) !important;
-    }
-  </style>
-</head>
-<!-- Font Awesome -->
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-RXf+QSDCUqzlgfO2z3lBU9rxO9xWJ6gU5AFVOIGuKz6ZlnbqybwVu6vZP4ylDkKUTnSR5Fctj/6aydcZ4IB3BQ==" referrerpolicy="no-referrer" rel="stylesheet"/>
-<!-- Main CSS -->
-<link href="/styles.css" rel="stylesheet"/>
-<title>LEM Building Surveying Ltd.</title>
-</meta></meta></meta></head>
-<body>
-<header>
-<div class="header-inner">
-<div class="branding">
-<a aria-label="LEM Building Surveying Ltd home" class="logo-link" href="/index.html">
-<img alt="LEM Building Surveying Ltd Logo" class="logo" src="/logo-sticker.png"/>
-<span class="site-name">LEM Building Surveying Ltd.</span>
-</a>
-</div>
-<nav aria-label="Main Navigation" class="main-nav">
-<ul>
-<li><a href="/index.html">Home</a></li>
-<li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
-<li><a class="cta" href="/enquiry.html">Get a Quote</a></li>
-</ul>
-</nav>
-</div>
-</header>
+          <label for="phone">Phone Number:</label>
+          <input id="phone" name="phone" required type="tel" />
 
-<!-- ENQUIRY PAGE -->
-<section class="enquiry-page">
-<div class="box-container">
-<h1>Request a Property Survey</h1>
-<p>Complete the form below and Liam will be in touch to confirm details or provide a tailored quote—no obligation.</p>
-<!-- Formspree: _next ensures redirect after successful send -->
-<form action="https://formspree.io/f/xzzdqqqz" class="enquiry-form" method="POST">
-<input name="_next" type="hidden" value="https://www.lembuildingsurveying.co.uk/thank-you.html"/>
-<label for="name">Full Name:</label>
-<input id="name" name="name" required="" type="text"/>
-<label for="email">Email Address:</label>
-<input id="email" name="email" required="" type="email"/>
-<label for="phone">Phone Number:</label>
-<input id="phone" name="phone" required="" type="tel"/>
-<label for="contact-method">Preferred Contact Method:</label>
-<select id="contact-method" name="contact-method" required="">
-<option value="">-- Please Select --</option>
-<option value="email">Email</option>
-<option value="phone-call">Phone Call</option>
-<option value="text-message">SMS / Text Message</option>
-<option value="whatsapp">WhatsApp</option>
-<option value="no-preference">No Preference</option>
-</select>
-<label for="survey-type">Survey Type:</label>
-<select id="survey-type" name="survey-type" required="">
-<option value="">-- Please Select --</option>
-<option value="level-1">RICS Level 1 Home Survey</option>
-<option value="level-2">RICS Level 2 Home Survey</option>
-<option value="level-3">RICS Level 3 Home Survey</option>
-<option value="damp">Damp &amp; Timber Report</option>
-<option value="epc">EPC with Floorplan</option>
-<option value="measured">Measured Survey &amp; Floorplan</option>
-<option value="ventilation">Ventilation Assessment</option>
-<option value="unsure">Unsure – Please advise</option>
-</select>
-<label for="address">Property Address:</label>
-<input id="address" name="address" placeholder="123 High Street, Flintshire" type="text"/>
-<label for="bedrooms">Number of Bedrooms:</label>
-<input id="bedrooms" min="0" name="bedrooms" placeholder="e.g. 3" type="number"/>
-<label for="details">Additional Notes:</label>
-<textarea id="details" name="details" placeholder="Any known issues, preferred times, or questions." rows="4"></textarea>
-<button class="cta-button" type="submit">Submit Enquiry</button>
-</form>
-<p class="thank-you-note">Thank you—we’ll be in touch shortly to help with your survey needs.</p>
-</div>
-</section>
-<!-- Shared Footer -->
-<div id="footer-include"></div>
-</body>
+          <label for="contact-method">Preferred Contact Method:</label>
+          <select id="contact-method" name="contact-method" required>
+            <option value="">-- Please Select --</option>
+            <option value="email">Email</option>
+            <option value="phone-call">Phone Call</option>
+            <option value="text-message">SMS / Text Message</option>
+            <option value="whatsapp">WhatsApp</option>
+            <option value="no-preference">No Preference</option>
+          </select>
 
-<script src="/nav.js"></script>
-</body></html>
+          <label for="survey-type">Survey Type:</label>
+          <select id="survey-type" name="survey-type" required>
+            <option value="">-- Please Select --</option>
+            <option value="level-1">RICS Level 1 Home Survey</option>
+            <option value="level-2">RICS Level 2 Home Survey</option>
+            <option value="level-3">RICS Level 3 Home Survey</option>
+            <option value="damp">Damp &amp; Timber Report</option>
+            <option value="epc">EPC with Floorplan</option>
+            <option value="measured">Measured Survey &amp; Floorplan</option>
+            <option value="ventilation">Ventilation Assessment</option>
+            <option value="unsure">Unsure – Please advise</option>
+          </select>
+
+          <label for="address">Property Address:</label>
+          <input
+            id="address"
+            name="address"
+            placeholder="123 High Street, Flintshire"
+            type="text"
+          />
+
+          <label for="bedrooms">Number of Bedrooms:</label>
+          <input
+            id="bedrooms"
+            name="bedrooms"
+            placeholder="e.g. 3"
+            type="number"
+            min="0"
+          />
+
+          <label for="details">Additional Notes:</label>
+          <textarea
+            id="details"
+            name="details"
+            placeholder="Any known issues, preferred times, or questions."
+            rows="4"
+          ></textarea>
+
+          <button class="cta-button" type="submit">Submit Enquiry</button>
+        </form>
+        <p class="thank-you-note">
+          Thank you—we’ll be in touch shortly to help with your survey needs.
+        </p>
+      </div>
+    </section>
+
+    <div id="footer-include"></div>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const form = document.querySelector(".enquiry-form");
+        form.addEventListener("submit", async (e) => {
+          e.preventDefault();
+          const data = new FormData(form);
+
+          const resp = await fetch("https://formspree.io/f/xzzdqqqz", {
+            method: "POST",
+            body: data,
+            headers: { Accept: "application/json" },
+          });
+
+          if (resp.ok) {
+            /* fire Google-Ads conversion before leaving */
+            gtag("event", "conversion", { send_to: "AW-XXXXXXXXXX/AbCdEFgHiJk" });
+            window.location = "/thank-you.html";
+          } else {
+            alert("Sorry, something went wrong. Please email us directly.");
+          }
+        });
+      });
+    </script>
+    <script src="/nav.js"></script>
+  </body>
+</html>
+

--- a/header.html
+++ b/header.html
@@ -25,13 +25,15 @@
       </a>
     </div>
     <nav class="main-nav" aria-label="Main Navigation">
+      <ul class="primary-links">
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
+        <li><a href="/services.html">Services</a></li>
+      </ul>
       <button class="nav-toggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
       <ul class="nav-links">
-        <li><a href="/index.html">Home</a></li>
-        <li><a href="/rics-home-surveys.html">RICS Home Surveys</a></li>
-        <li><a href="/services.html">Services</a></li>
         <li><a href="/local-surveys.html">Areas We Cover</a></li>
         <li><a href="/comparison.html">Pricing</a></li>
         <li><a href="/testimonials.html">Testimonials</a></li>

--- a/nav.js
+++ b/nav.js
@@ -37,14 +37,15 @@
   function setupNav(){
     var navToggle = document.querySelector('.nav-toggle');
     var navLinks = document.querySelector('.nav-links');
-    if (!navToggle || !navLinks) return;
-    navToggle.addEventListener('click', function(){
-      navLinks.classList.toggle('nav-open');
-      navToggle.classList.toggle('open');
-    });
+    if (navToggle && navLinks) {
+      navToggle.addEventListener('click', function(){
+        navLinks.classList.toggle('nav-open');
+        navToggle.classList.toggle('open');
+      });
+    }
 
     var path = window.location.pathname;
-    navLinks.querySelectorAll('a').forEach(function(link){
+    document.querySelectorAll('.main-nav a').forEach(function(link){
       var href = link.getAttribute('href');
       if (href === path || (path === '/' && href === '/index.html')) {
         link.setAttribute('aria-current', 'page');

--- a/styles.css
+++ b/styles.css
@@ -49,9 +49,25 @@ header {
   font-size: 1.2rem; font-weight: bold; color: #fff;
   line-height: 1; margin-top: -.2rem;
 }
-.nav-links {
+.main-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.primary-links {
   list-style: none; display: flex; gap: 1rem;
   flex-wrap: wrap; justify-content: center;
+}
+
+.nav-links {
+  list-style: none;
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.nav-links.nav-open {
+  display: flex;
 }
 .main-nav a {
   color: #fff; text-decoration: none; font-weight: bold;
@@ -652,8 +668,9 @@ form button:hover, .quote-form button:hover {
 .trust-features .section-title--blue,
 .process-timeline .section-title--blue {
   margin-bottom: 1.5rem;
-}.nav-toggle {
-  display: none;
+}
+.nav-toggle {
+  display: flex;
   flex-direction: column;
   gap: 5px;
   background: none;
@@ -680,16 +697,7 @@ form button:hover, .quote-form button:hover {
 }
 
 @media (max-width: 700px) {
-  .nav-toggle {
-    display: flex;
-  }
   .nav-links {
-    display: none;
-    flex-direction: column;
-    gap: 1rem;
     width: 100%;
-  }
-  .nav-links.nav-open {
-    display: flex;
   }
 }


### PR DESCRIPTION
## Summary
- Clean up `enquiry.html` by removing duplicated `<head>` and `<body>` sections and rebuilding the head with shared resources.
- Insert header include placeholder at the top of the body and ensure footer and nav script remain in place.
- Move form handling script to the end of the body for cleaner structure.
- Restructure shared header so only Home, RICS Home Surveys and Services are immediately visible, placing remaining links behind a toggle.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f7e9b773c8323a5c3e36f922ff35c